### PR TITLE
Support Other Language like Chinese

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,7 +54,7 @@ Example of a valid JSON response:
         
         steps.append((f"Step {step_count}: {step_data['title']}", step_data['content'], thinking_time))
         
-        messages.append({"role": "assistant", "content": json.dumps(step_data)})
+        messages.append({"role": "assistant", "content": json.dumps(step_data, ensure_ascii=False)})
         
         if step_data['next_action'] == 'final_answer' or step_count > 25: # Maximum of 25 steps to prevent infinite thinking time. Can be adjusted.
             break


### PR DESCRIPTION
force Ascii for json packaging will cause invalid json 
like 
```
ERROR= Error code: 400 - {'error': {'message': "Failed to generate JSON. Please adjust your prompt. See 'failed_generation' for more details.", 'type': 'invalid_request_error', 'code': 'json_validate_failed', 'failed_generation': '```json\n{\n   "title": "\\u7ed3\\u7b97\\u7b54\\u6848",\n   "content": "\\u4e3a\\u4e86\\u7b97\\u51fa\\u81f3\\u5c11\\u6709\\u4e00\\u53ea\\u9e1f\\u88ab\\u51fb\\u4e2d\\uff0c\\u6211\\u4eec\\u8ba9\\u4e00\\u53ea\\u9e1f\\u88ab\\u51fb\\u4e2d\\uff0c\\u5176\\u6b61\\u4e00\\u53ea\\u9e1f\\u6ca1\\u88ab\\u51fb\\u4e2d\\uff0c\\u5e76\\u4e14\\u6ca1\\u6709\\u5176\\u4ed6\\u56e0\\u7d20\\u4f1a\\u5f71\\u54cd\\u9e1f\\u768'}}
```

![image](https://github.com/user-attachments/assets/d7e9f21f-8418-4de9-9517-d6caf7eef457)


after the fix ,all is good 
![image](https://github.com/user-attachments/assets/ca69a833-ba89-439a-8e77-7dc8ca8db921)
