### PR TITLE
added a Huggingface space demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The reasoning ability of the LLM is therefore improved through combining Chain-o
 
 
 ##### How many Rs are in strawberry?
+
 Prompt: How many Rs are in strawberry?
 
 Result:
@@ -41,10 +42,6 @@ Result:
 
 
 ### Quickstart
-
-**Demo:**
-
-[![Hugging Face Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/xylin/g1-demo)
 
 To use the Streamlit UI, follow these instructions:
 
@@ -141,6 +138,8 @@ Finally, after the problem is added as a user message, an assistant message is l
 
 
 ### Top Forks
+
+* Huggingface Spaces Demo: [![Hugging Face Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/xylin/g1-demo)
 * Mult1: Using multiple AI providers to create o1-like reasoning chains ([GitHub Repository](https://github.com/tcsenpai/multi1))
 * thinkR: o1 like chain of thoughts with local LLMs in R ([GitHub Repository](https://github.com/eonurk/thinkR))
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Result:
 
 ### Quickstart
 
+**Demo:**
+
+[![Hugging Face Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/xylin/g1-demo)
+
 To use the Streamlit UI, follow these instructions:
 
 ~~~


### PR DESCRIPTION
i deployed the gradio app in huggingface spaces with adding 2 modes, "public" and "private", the "public" mode uses a free pre-configured groq API key, so anyone can access and chat with g1 publically without entering it's own groq API key, but incase of reaching api request limits and usage limits of the pre-configured public API key you can switch to "private" mode wich will show an input to input your own and private groq API key and use it (like original gradio app).

By the way, used Huggingface space demo is [here](https://huggingface.co/spaces/xylin/g1-demo)